### PR TITLE
Fix webkit border-radius bug

### DIFF
--- a/theme.less
+++ b/theme.less
@@ -10,6 +10,10 @@
     white-space: nowrap;
     background: transparent;
     }
+	
+.kralahmet-container {
+	-webkit-mask-image: -webkit-radial-gradient(white, black);
+}
 
 .kralahmet .content .title>a {
     white-space: nowrap;


### PR DESCRIPTION
I added a simple LESS/CSS rule to fix [this](https://forum.webflow.com/t/overflow-hidden-round-corners-not-working-on-safari/67805/3) bug on Chrome and Safari.